### PR TITLE
Add RequestContext and RouteResult to Java DSL

### DIFF
--- a/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Directives.scala
@@ -4,7 +4,6 @@
 
 package akka.http.javadsl.server
 
-import akka.http.scaladsl.server.Rejection
 import scala.annotation.varargs
 import akka.http.javadsl.model.HttpMethods
 import akka.http.javadsl.server.directives.{ TimeoutDirectives, WebSocketDirectives }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/JavaScalaTypeEquivalence.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/JavaScalaTypeEquivalence.scala
@@ -68,7 +68,9 @@ object JavaScalaTypeEquivalence {
   implicit val javaToScalaEntityTag = TypeEquivalent[javadsl.model.headers.EntityTag, scaladsl.model.headers.EntityTag]
   implicit val javaToScalaDateTime = TypeEquivalent[javadsl.model.DateTime, scaladsl.model.DateTime]
   implicit val javaToScalaRouteSettings = TypeEquivalent[javadsl.settings.RoutingSettings, scaladsl.settings.RoutingSettings]
+  implicit val javaToScalaParserSettings = TypeEquivalent[javadsl.settings.ParserSettings, scaladsl.settings.ParserSettings]
   implicit val javaToScalaLogEntry = TypeEquivalent[javadsl.server.directives.LogEntry, scaladsl.server.directives.LogEntry]
+  implicit val javaToScalaRejection = TypeEquivalent[javadsl.server.Rejection, scaladsl.server.Rejection]
 
   // not made implicit since these are subtypes of RequestEntity
   val javaToScalaHttpEntity = TypeEquivalent[javadsl.model.HttpEntity, scaladsl.model.HttpEntity]

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejection.scala
@@ -1,0 +1,3 @@
+package akka.http.javadsl.server
+
+trait Rejection {}

--- a/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/Rejections.scala
@@ -86,7 +86,7 @@ object Rejections {
   def validationRejection(message: String, cause: Optional[Throwable]) = ValidationRejection(message, cause.asScala)
 
   def transformationRejection(f: java.util.function.Function[java.util.List[Rejection], java.util.List[Rejection]]) =
-    TransformationRejection(rejections ⇒ f.apply(rejections.asJava).asScala.toVector)
+    TransformationRejection(rejections ⇒ f.apply(rejections.map(r => r:Rejection).asJava).asScala.toVector)
 
   def rejectionError(rejection: Rejection) = RejectionError(rejection)
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RequestContext.scala
@@ -1,0 +1,64 @@
+package akka.http.javadsl.server
+
+import akka.http.javadsl.model.HttpRequest
+import scala.concurrent.ExecutionContextExecutor
+import akka.stream.Materializer
+import akka.event.LoggingAdapter
+import akka.http.javadsl.settings.RoutingSettings
+import akka.http.javadsl.settings.ParserSettings
+import akka.http.javadsl.model.HttpResponse
+import java.util.concurrent.CompletionStage
+import java.util.function.{Function => JFunction}
+import akka.http.scaladsl
+import akka.http.javadsl.server.JavaScalaTypeEquivalence._
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import scala.compat.java8.FutureConverters._
+import scala.annotation.varargs
+import akka.http.scaladsl.model.Uri.Path
+
+class RequestContext private (delegate: scaladsl.server.RequestContext) {
+  import RequestContext._
+  import scala.concurrent.ExecutionContext.Implicits.global // only for type-converting future.map
+  
+  def getRequest(): HttpRequest = delegate.request
+  def getUnmatchedPath(): String = delegate.unmatchedPath.toString()
+  def getExecutionContext(): ExecutionContextExecutor = delegate.executionContext
+  def getMaterializer(): Materializer = delegate.materializer
+  def getLog(): LoggingAdapter = delegate.log
+  def getSettings(): RoutingSettings = delegate.settings
+  def getParserSettings(): ParserSettings = delegate.parserSettings
+  
+  def reconfigure(
+    executionContext: ExecutionContextExecutor,
+    materializer: Materializer,
+    log: LoggingAdapter,
+    settings: RoutingSettings): RequestContext = wrap(delegate.reconfigure(executionContext, materializer, log, settings))
+  
+  def complete[T](value: T, marshaller: Marshaller[T, HttpResponse]): CompletionStage[RouteResult] = {
+    import marshaller.asScala
+    delegate.complete(ToResponseMarshallable(value)(marshaller.asScala)).map(r => r:RouteResult).toJava
+  }
+  
+  @varargs def reject(rejections: Rejection*): CompletionStage[RouteResult] = {
+    val scalaRejections = rejections.map(r => r:scaladsl.server.Rejection)
+    delegate.reject(scalaRejections: _*).map(r => r:RouteResult).toJava
+  }
+  
+  def fail(error: Throwable): CompletionStage[RouteResult] = delegate.fail(error).map(r => r:RouteResult).toJava
+  def withRequest(req: HttpRequest): RequestContext = wrap(delegate.withRequest(req))
+  def withExecutionContext(ec: ExecutionContextExecutor): RequestContext = wrap(delegate.withExecutionContext(ec))
+  def withMaterializer(materializer: Materializer): RequestContext = wrap(delegate.withMaterializer(materializer))
+  def withLog(log: LoggingAdapter): RequestContext = wrap(delegate.withLog(log))
+  def withRoutingSettings(settings: RoutingSettings): RequestContext = wrap(delegate.withRoutingSettings(settings))
+  def withParserSettings(settings: ParserSettings): RequestContext = wrap(delegate.withParserSettings(settings))
+  
+  def mapRequest(f: JFunction[HttpRequest, HttpRequest]): RequestContext = wrap(delegate.mapRequest(r => f.apply(r)))
+  def withUnmatchedPath(path: String): RequestContext = wrap(delegate.withUnmatchedPath(Path(path)))
+  def mapUnmatchedPath(f: JFunction[String, String]): RequestContext = wrap(delegate.mapUnmatchedPath(p => Path(f.apply(p.toString()))))
+  def withAcceptAll: RequestContext = wrap(delegate.withAcceptAll)
+}
+
+object RequestContext {
+  /** INTERNAL API */
+  private[server] def wrap(delegate: scaladsl.server.RequestContext) = new RequestContext(delegate)
+}

--- a/akka-http/src/main/scala/akka/http/javadsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/RouteResult.scala
@@ -1,0 +1,13 @@
+package akka.http.javadsl.server
+
+import akka.http.javadsl.model.HttpResponse
+
+trait RouteResult {}
+
+trait Complete extends RouteResult {
+  def getResponse: HttpResponse
+}
+
+trait Rejected extends RouteResult {
+  def getRejections: java.lang.Iterable[Rejection]
+}

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/BasicDirectives.scala
@@ -6,7 +6,6 @@ package akka.http.javadsl.server.directives
 
 import java.util.function.{ Function ⇒ JFunction }
 import akka.http.javadsl.settings.ParserSettings
-import akka.http.scaladsl.server.directives.BasicDirectives
 import akka.http.scaladsl.settings.RoutingSettings
 
 import scala.concurrent.ExecutionContextExecutor
@@ -28,6 +27,7 @@ import akka.http.javadsl.model.HttpHeader
 import java.lang.{ Iterable ⇒ JIterable }
 import java.util.function.Predicate
 import akka.event.LoggingAdapter
+import akka.http.javadsl.server.RequestContext
 
 abstract class BasicDirectives {
   def mapRequest(f: JFunction[HttpRequest, HttpRequest], inner: Supplier[Route]): Route = ScalaRoute {
@@ -134,7 +134,7 @@ abstract class BasicDirectives {
    * Extracts a single value using the given function.
    */
   def extract[T](extract: JFunction[RequestContext, T], inner: JFunction[T, Route]): Route = ScalaRoute {
-    D.extract(extract.apply) { c ⇒ inner.apply(c).toScala }
+    D.extract(ctx => extract.apply(RequestContext.wrap(ctx))) { c ⇒ inner.apply(c).toScala }
   }
 
   /**
@@ -168,4 +168,12 @@ abstract class BasicDirectives {
       inner.apply(settings).toScala
     }
   }
+  
+  /**
+   * Extracts the [[akka.http.javadsl.server.RequestContext]] itself.
+   */
+  def extractRequestContext(inner: JFunction[RequestContext, Route]) = ScalaRoute {
+    D.extractRequestContext { ctx => inner.apply(RequestContext.wrap(ctx)).toScala }
+  }
+  
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -5,7 +5,6 @@ package akka.http.javadsl.server.directives
 
 import scala.annotation.varargs
 import scala.collection.JavaConverters._
-
 import akka.http.impl.model.JavaUri
 import akka.http.javadsl.model.HttpHeader
 import akka.http.javadsl.model.HttpResponse
@@ -19,9 +18,8 @@ import akka.http.scaladsl
 import akka.http.scaladsl.marshalling.Marshaller._
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
 import akka.http.scaladsl.model.StatusCodes.Redirection
-import akka.http.scaladsl.server.Rejection
-
 import akka.http.scaladsl.server.directives.{ RouteDirectives ⇒ D }
+import akka.http.javadsl.server.Rejection
 
 abstract class RouteDirectives extends RespondWithDirectives {
   /**

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/ScalaRoute.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/ScalaRoute.scala
@@ -9,7 +9,6 @@ import akka.http.javadsl.model.HttpRequest
 import akka.http.javadsl.model.HttpResponse
 import akka.http.javadsl.server.JavaScalaTypeEquivalence._
 import akka.http.javadsl.server.Route
-import akka.http.javadsl.server.directives.ScalaRoute
 import akka.http.scaladsl
 import akka.http.scaladsl.server.RouteConcatenation._
 import akka.stream.Materializer

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/Rejection.scala
@@ -13,7 +13,7 @@ import headers._
  * up over the course of a Route evaluation and finally converted to [[akka.http.scaladsl.model.HttpResponse]]s by the
  * `handleRejections` directive, if there was no way for the request to be completed.
  */
-trait Rejection
+trait Rejection extends akka.http.javadsl.server.Rejection
 
 /**
  * Rejection created by method filters.

--- a/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
+++ b/akka-http/src/main/scala/akka/http/scaladsl/server/RouteResult.scala
@@ -11,6 +11,8 @@ import akka.http.scaladsl.settings.{ RoutingSettings, ParserSettings }
 import akka.stream.Materializer
 import akka.stream.scaladsl.Flow
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.javadsl
+import scala.collection.JavaConverters._
 
 /**
  * The result of handling a request.
@@ -18,11 +20,15 @@ import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
  * As a user you typically don't create RouteResult instances directly.
  * Instead, use the methods on the [[RequestContext]] to achieve the desired effect.
  */
-sealed trait RouteResult
+sealed trait RouteResult extends javadsl.server.RouteResult
 
 object RouteResult {
-  final case class Complete(response: HttpResponse) extends RouteResult
-  final case class Rejected(rejections: immutable.Seq[Rejection]) extends RouteResult
+  final case class Complete(response: HttpResponse) extends javadsl.server.Complete with RouteResult {
+    override def getResponse = response
+  }
+  final case class Rejected(rejections: immutable.Seq[Rejection]) extends javadsl.server.Rejected with RouteResult {
+    override def getRejections = rejections.map(r => r:javadsl.server.Rejection).toIterable.asJava
+  }
 
   implicit def route2HandlerFlow(route: Route)(implicit routingSettings: RoutingSettings,
                                                parserSettings: ParserSettings,


### PR DESCRIPTION
I ended up creating a delegate pattern, since merging the two interfaces would be impossible if we want both Java and Scala to have e.g. a `fail` method but with different return types.
