### PR TITLE
[act] Allow PFBuilder cases without type and only predicate

### DIFF
--- a/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/PFBuilderTest.java
@@ -21,4 +21,15 @@ public class PFBuilderTest {
     assertTrue(pf.isDefinedAt("42"));
     assertEquals(42, pf.apply("42").intValue());
   }
+  
+  @Test
+  public void typed_pfbuilder_can_match_with_only_predicate_argument() {
+    PartialFunction<String,Integer> pf = new PFBuilder<String,Integer>()
+      .match(String::isEmpty, emptyString -> 42)
+      .build();
+    
+    assertTrue(pf.isDefinedAt(""));
+    assertEquals(42, pf.apply("").intValue());
+    assertFalse(pf.isDefinedAt("42"));
+  }
 }

--- a/akka-actor-tests/src/test/java/akka/japi/pf/ReceiveBuilderTest.java
+++ b/akka-actor-tests/src/test/java/akka/japi/pf/ReceiveBuilderTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2009-2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.japi.pf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import scala.PartialFunction;
+import scala.runtime.BoxedUnit;
+
+public class ReceiveBuilderTest {
+    @Test
+    public void typed_receivebuilder_can_match_with_only_predicate_argument() {
+      AtomicInteger matched = new AtomicInteger();
+        
+      PartialFunction<Object,BoxedUnit> pf = ReceiveBuilder
+        .match(String::isEmpty, emptyString -> matched.incrementAndGet())
+        .build();
+      
+      assertFalse(pf.isDefinedAt("42"));
+      assertEquals(0, matched.get());
+      
+      assertTrue(pf.isDefinedAt(""));
+      assertEquals(0, matched.get());
+      
+      pf.apply("");
+      assertEquals(1, matched.get());
+    }
+
+}

--- a/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/PFBuilder.java
@@ -72,6 +72,28 @@ public final class PFBuilder<I, R> extends AbstractPFBuilder<I, R> {
   /**
    * Add a new case statement to this builder.
    *
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the type matches and the predicate returns true
+   * @return a builder with the case statement added
+   */
+  @SuppressWarnings("unchecked")
+  public <P> PFBuilder<I, R> match(final FI.TypedPredicate<? extends P> predicate,
+                                   final FI.Apply<? extends P, R> apply) {
+    FI.Predicate fiPredicate = new FI.Predicate() {
+      @Override
+      public boolean defined(Object o) {
+        @SuppressWarnings("unchecked")
+        P p = (P) o;
+        return ((FI.TypedPredicate<P>) predicate).defined(p);
+      }
+    };
+    addStatement(new CaseStatement<I, P, R>(fiPredicate, (FI.Apply<P, R>) apply));
+    return this;
+  }
+
+  /**
+   * Add a new case statement to this builder.
+   *
    * @param object the object to compare equals with
    * @param apply  an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added

--- a/akka-actor/src/main/java/akka/japi/pf/ReceiveBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/ReceiveBuilder.java
@@ -64,6 +64,18 @@ public class ReceiveBuilder {
   /**
    * Return a new {@link UnitPFBuilder} with a case statement added.
    *
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the type matches and the predicate returns true
+   * @return a builder with the case statement added
+   */
+  public static <P> UnitPFBuilder<Object> match(FI.TypedPredicate<? extends P> predicate,
+                                                FI.UnitApply<? extends P> apply) {
+    return UnitMatch.match(predicate, apply);
+  }
+
+  /**
+   * Return a new {@link UnitPFBuilder} with a case statement added.
+   *
    * @param object the object to compare equals with
    * @param apply  an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added

--- a/akka-actor/src/main/java/akka/japi/pf/UnitMatch.java
+++ b/akka-actor/src/main/java/akka/japi/pf/UnitMatch.java
@@ -53,6 +53,20 @@ public class UnitMatch<I> extends AbstractMatch<I, BoxedUnit> {
    * Convenience function to create a {@link UnitPFBuilder} with the first
    * case statement added.
    *
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the type and predicate matches
+   * @return a builder with the case statement added
+   * @see UnitPFBuilder#match(Class, FI.TypedPredicate, FI.UnitApply)
+   */
+  public static <F, P> UnitPFBuilder<F> match(final FI.TypedPredicate<? extends P> predicate,
+                                              final FI.UnitApply<? extends P> apply) {
+    return new UnitPFBuilder<F>().match(predicate, apply);
+  }
+  
+  /**
+   * Convenience function to create a {@link UnitPFBuilder} with the first
+   * case statement added.
+   *
    * @param object the object to compare equals with
    * @param apply  an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added

--- a/akka-actor/src/main/java/akka/japi/pf/UnitPFBuilder.java
+++ b/akka-actor/src/main/java/akka/japi/pf/UnitPFBuilder.java
@@ -79,6 +79,30 @@ public final class UnitPFBuilder<I> extends AbstractPFBuilder<I, BoxedUnit> {
   /**
    * Add a new case statement to this builder.
    *
+   * @param predicate a predicate that will be evaluated on the argument if the type matches
+   * @param apply     an action to apply to the argument if the type matches and the predicate returns true
+   * @return a builder with the case statement added
+   */
+  @SuppressWarnings("unchecked")
+  public <P> UnitPFBuilder<I> match(final FI.TypedPredicate<? extends P> predicate,
+                                    final FI.UnitApply<? extends P> apply) {
+    FI.Predicate fiPredicate = new FI.Predicate() {
+      @Override
+      public boolean defined(Object o) {
+        @SuppressWarnings("unchecked")
+        P p = (P) o;
+        return ((FI.TypedPredicate<P>) predicate).defined(p);
+      }
+    };
+
+    addStatement(new UnitCaseStatement<I, P>(fiPredicate, (FI.UnitApply<P>) apply));
+
+    return this;
+  }
+
+  /**
+   * Add a new case statement to this builder.
+   *
    * @param object the object to compare equals with
    * @param apply  an action to apply to the argument if the object compares equal
    * @return a builder with the case statement added


### PR DESCRIPTION
This is especially useful when you have a typed `PFBuilder` that's not just `Object`, e.g. `PFBuilder<Event,Void>` and you just want to say:

```
b.match(Event::isMyType, evt -> doStuff())
```

without having to repeat `Event.class` as first argument.

@ktoso I hope we can include this in the DSL changes we're doing already. And they're just new methods, so no binary changes (and PFBuilder is still marked experimental anyways).
