### PR TITLE
Bugfix in java reject and a little test-boyscouting

### DIFF
--- a/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ExecutionDirectivesTest.java
+++ b/akka-http-tests/src/test/java/akka/http/javadsl/server/directives/ExecutionDirectivesTest.java
@@ -40,7 +40,7 @@ public class ExecutionDirectivesTest extends JUnitRouteTest {
             .assertEntity("The result is: 2");
 
         route.run(HttpRequest.GET("/divide?a=10&b=0"))
-            .assertStatusCode(400)
+            .assertStatusCode(StatusCodes.BAD_REQUEST)
             .assertEntity("Congratulations you provoked a division by zero!");
     }
 
@@ -58,11 +58,11 @@ public class ExecutionDirectivesTest extends JUnitRouteTest {
             );
 
         route.run(HttpRequest.GET("/"))
-            .assertStatusCode(200)
+            .assertStatusCode(StatusCodes.OK)
             .assertEntity("Successful!");
 
         route.run(HttpRequest.POST("/"))
-            .assertStatusCode(400)
+            .assertStatusCode(StatusCodes.BAD_REQUEST)
             .assertEntity("Whoopsie! Unsupported method. Supported would have been GET");
     }
 
@@ -89,10 +89,10 @@ public class ExecutionDirectivesTest extends JUnitRouteTest {
         TestRoute route = testRoute(handleRejections(rejectionHandler, () -> testRoute));
 
         route.run(HttpRequest.GET("/test"))
-                .assertStatusCode(200);
+                .assertStatusCode(StatusCodes.OK);
 
         route.run(HttpRequest.GET("/other"))
-                .assertStatusCode(429)
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS)
                 .assertEntity("Too many requests for busy path!");
     }
 }

--- a/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
+++ b/akka-http/src/main/scala/akka/http/javadsl/server/directives/RouteDirectives.scala
@@ -50,7 +50,7 @@ abstract class RouteDirectives extends RespondWithDirectives {
    * Rejects the request with the given rejections, or with an empty set of rejections if no rejections are given.
    */
   @varargs def reject(rejection: Rejection, rejections: Rejection*): Route = RouteAdapter {
-    D.reject(rejections.map(_.asScala): _*)
+    D.reject((rejection +: rejections).map(_.asScala): _*)
   }
 
   /**


### PR DESCRIPTION
Java-reject was omitting first parameter from the rejections it actually sent on in to the scala dsl.

Not sure if I should be more concerned about performance and prepending.
