### PR TITLE
all doc warnings squashed 

### DIFF
--- a/akka-docs/rst/java/http/client-side/connection-level.rst
+++ b/akka-docs/rst/java/http/client-side/connection-level.rst
@@ -61,7 +61,7 @@ explicitly drained by attaching it to ``Sink.ignore()``.
 Timeouts
 --------
 
-Timeouts are configured in the same way for Scala and Akka. See :ref:`_http-timeouts-java` .
+Timeouts are configured in the same way for Scala and Akka. See :ref:`http-timeouts-java` .
 
 .. _http-client-layer-java:
 

--- a/akka-docs/rst/java/http/index.rst
+++ b/akka-docs/rst/java/http/index.rst
@@ -36,6 +36,7 @@ akka-http-jackson
    server-side/websocket-support
    routing-dsl/index
    client-side/index
+   common/index
    configuration
 
 .. _jackson: https://github.com/FasterXML/jackson

--- a/akka-docs/rst/java/http/routing-dsl/directives/alphabetically.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/alphabetically.rst
@@ -136,12 +136,12 @@ Directive                                        Description
 :ref:`-setCookie-java-`                          Adds a ``Set-Cookie`` response header with the given cookies
 :ref:`-uploadedFile-java-`                       Streams one uploaded file from a multipart request to a file on disk
 :ref:`-validate-java-`                           Checks a given condition before running its inner route
-:ref:`-withoutRequestTimeout-java-`              Disables :ref:`request timeouts <request-timeout>` for a given route.
+:ref:`-withoutRequestTimeout-java-`              Disables :ref:`request timeouts <request-timeout-java>` for a given route.
 :ref:`-withExecutionContext-java-`               Runs its inner route with the given alternative ``ExecutionContext``
 :ref:`-withMaterializer-java-`                   Runs its inner route with the given alternative ``Materializer``
 :ref:`-withLog-java-`                            Runs its inner route with the given alternative ``LoggingAdapter``
 :ref:`-withRangeSupport-java-`                   Adds ``Accept-Ranges: bytes`` to responses to GET requests, produces partial responses if the initial request contained a valid ``Range`` header
-:ref:`-withRequestTimeout-java-`                 Configures the :ref:`request timeouts <request-timeout>` for a given route.
+:ref:`-withRequestTimeout-java-`                 Configures the :ref:`request timeouts <request-timeout-java>` for a given route.
 :ref:`-withRequestTimeoutResponse-java-`         Prepares the ``HttpResponse`` that is emitted if a request timeout is triggered. ``RequestContext => RequestContext`` function
 :ref:`-withSettings-java-`                       Runs its inner route with the given alternative ``RoutingSettings``
 ================================================ ============================================================================

--- a/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withRequestTimeout.rst
+++ b/akka-docs/rst/java/http/routing-dsl/directives/timeout-directives/withRequestTimeout.rst
@@ -6,7 +6,7 @@ withRequestTimeout
 Description
 -----------
 
-This directive enables "late" (during request processing) control over the :ref:`request-timeout` feature in Akka HTTP.
+This directive enables "late" (during request processing) control over the :ref:`request-timeout-java` feature in Akka HTTP.
 
 The timeout can be either loosened or made more tight using this directive, however one should be aware that it is
 inherently racy (which may especially show with very tight timeouts) since a timeout may already have been triggered

--- a/akka-docs/rst/scala/http/routing-dsl/case-class-extraction.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/case-class-extraction.rst
@@ -10,7 +10,7 @@ Consider this example:
 .. includecode2:: ../../code/docs/http/scaladsl/server/CaseClassExtractionExamplesSpec.scala
    :snippet: example-1
 
-Here the :ref:`-parameters-` directives is employed to extract three ``Int`` values, which are then used to construct an
+Here the :ref:`-parameters-scala-` directives is employed to extract three ``Int`` values, which are then used to construct an
 instance of the ``Color`` case class. So far so good. However, if the model classes we'd like to work with have more
 than just a few parameters the overhead introduced by capturing the arguments as extractions only to feed them into the
 model class constructor directly afterwards can somewhat clutter up your route definitions.

--- a/akka-docs/rst/scala/http/routing-dsl/directives/alphabetically.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/alphabetically.rst
@@ -64,7 +64,7 @@ Directive                                   Description
 :ref:`-failWith-`                           Bubbles the given error up the response chain where it is dealt with by the
                                             closest :ref:`-handleExceptions-` directive and its ``ExceptionHandler``
 :ref:`-fileUpload-`                         Provides a stream of an uploaded file from a multipart request
-:ref:`-formField-`                          Extracts an HTTP form field from the request
+:ref:`-formField-scala-`                    Extracts an HTTP form field from the request
 :ref:`-formFieldMap-`                       Extracts a number of HTTP form field from the request as
                                             a ``Map[String, String]``
 :ref:`-formFieldMultiMap-`                  Extracts a number of HTTP form field from the request as
@@ -150,7 +150,7 @@ Directive                                   Description
 :ref:`-parameter-`                          Extracts a query parameter value from the request
 :ref:`-parameterMap-`                       Extracts the request's query parameters as a ``Map[String, String]``
 :ref:`-parameterMultiMap-`                  Extracts the request's query parameters as a ``Map[String, List[String]]``
-:ref:`-parameters-`                         Extracts a number of query parameter values from the request
+:ref:`-parameters-scala-`                   Extracts a number of query parameter values from the request
 :ref:`-parameterSeq-`                       Extracts the request's query parameters as a ``Seq[(String, String)]``
 :ref:`-pass-`                               Always simply passes the request on to its inner route, i.e. doesn't do
                                             anything, neither with the request nor the response
@@ -211,13 +211,13 @@ Directive                                   Description
 :ref:`-tprovide-`                           Injects a given tuple of values into a directive
 :ref:`-uploadedFile-`                       Streams one uploaded file from a multipart request to a file on disk
 :ref:`-validate-`                           Checks a given condition before running its inner route
-:ref:`-withoutRequestTimeout-`              Disables :ref:`request timeouts <request-timeout>` for a given route.
+:ref:`-withoutRequestTimeout-`              Disables :ref:`request timeouts <request-timeout-scala>` for a given route.
 :ref:`-withExecutionContext-`               Runs its inner route with the given alternative ``ExecutionContext``
 :ref:`-withMaterializer-`                   Runs its inner route with the given alternative ``Materializer``
 :ref:`-withLog-`                            Runs its inner route with the given alternative ``LoggingAdapter``
 :ref:`-withRangeSupport-`                   Adds ``Accept-Ranges: bytes`` to responses to GET requests, produces partial
                                             responses if the initial request contained a valid ``Range`` header
-:ref:`-withRequestTimeout-`                 Configures the :ref:`request timeouts <request-timeout>` for a given route.
+:ref:`-withRequestTimeout-`                 Configures the :ref:`request timeouts <request-timeout-scala>` for a given route.
 :ref:`-withRequestTimeoutResponse-`         Prepares the ``HttpResponse`` that is emitted if a request timeout is triggered.
                                             ``RequestContext => RequestContext`` function
 :ref:`-withSettings-`                       Runs its inner route with the given alternative ``RoutingSettings``

--- a/akka-docs/rst/scala/http/routing-dsl/directives/parameter-directives/index.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/parameter-directives/index.rst
@@ -17,19 +17,19 @@ ParameterDirectives
 When to use which parameter directive?
 --------------------------------------
 
-Usually, you want to use the high-level :ref:`-parameters-` directive. When you need
+Usually, you want to use the high-level :ref:`-parameters-scala-` directive. When you need
 more low-level access you can use the table below to decide which directive
 to use which shows properties of different parameter directives.
 
-========================== ====== ======== =====
-directive                  level  ordering multi
-========================== ====== ======== =====
-:ref:`-parameter-`         high   no       no
-:ref:`-parameters-`        high   no       yes
-:ref:`-parameterMap-`      low    no       no
-:ref:`-parameterMultiMap-` low    no       yes
-:ref:`-parameterSeq-`      low    yes      yes
-========================== ====== ======== =====
+================================ ====== ======== =====
+directive                        level  ordering multi
+================================ ====== ======== =====
+:ref:`-parameter-`               high   no       no
+:ref:`-parameters-scala-`        high   no       yes
+:ref:`-parameterMap-`            low    no       no
+:ref:`-parameterMultiMap-`       low    no       yes
+:ref:`-parameterSeq-`            low    yes      yes
+================================ ====== ======== =====
 
 level
     high-level parameter directives extract subset of all parameters by name and allow conversions

--- a/akka-docs/rst/scala/http/routing-dsl/directives/parameter-directives/parameter.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/parameter-directives/parameter.rst
@@ -13,7 +13,7 @@ Description
 -----------
 Extracts a *query* parameter value from the request.
 
-See :ref:`-parameters-` for a detailed description of this directive.
+See :ref:`-parameters-scala-` for a detailed description of this directive.
 
 See :ref:`which-parameter-directive` to understand when to use which directive.
 

--- a/akka-docs/rst/scala/http/routing-dsl/directives/timeout-directives/withRequestTimeoutResponse.rst
+++ b/akka-docs/rst/scala/http/routing-dsl/directives/timeout-directives/withRequestTimeoutResponse.rst
@@ -12,7 +12,7 @@ Signature
 Description
 -----------
 
-Allows customising the ``HttpResponse`` that will be sent to clients in case of a :ref:`request-timeout`.
+Allows customising the ``HttpResponse`` that will be sent to clients in case of a :ref:`request-timeout-scala`.
 
 See also :ref:`-withRequestTimeout-` or :ref:`-withoutRequestTimeout-` if interested in dynamically changing the timeout
 for a given route instead.


### PR DESCRIPTION
Only `Could not lex literal_block` ones left now
